### PR TITLE
fix(sandbox): Use pip to install uv in Docker build

### DIFF
--- a/docker/Dockerfile.sandbox
+++ b/docker/Dockerfile.sandbox
@@ -10,6 +10,7 @@ ARG EXTRA_PYTHON_PACKAGES=""
 
 # Install common utilities + optional apt packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
     curl \
     wget \
     jq \
@@ -19,13 +20,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     tree \
     unzip \
     ${EXTRA_APT_PACKAGES} \
+    && update-ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
 
-# Install uv for fast Python package management (in shared location)
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh \
-    && mv /root/.local/bin/uv /usr/local/bin/uv \
-    && mv /root/.local/bin/uvx /usr/local/bin/uvx
+# Install uv for fast Python package management
+RUN pip install --no-cache-dir uv
 
 # Copy workspace packages
 COPY packages/ash-rpc-protocol /tmp/ash-rpc-protocol


### PR DESCRIPTION
## Summary
- Fix sandbox Docker build failing due to SSL certificate issues when using curl to download uv installer
- Use pip to install uv instead, avoiding SSL verification problems in Docker build environments

## What changed
- Install `uv` via `pip install uv` instead of curl-based installer script (`docker/Dockerfile.sandbox`)
- Removed manual `mv` commands to relocate binaries - pip installs `uv` and `uvx` directly to `/usr/local/bin/`
- Add explicit `ca-certificates` package and run `update-ca-certificates` for other curl/wget operations

## Why
The curl-based uv installer fails in some Docker build environments due to SSL certificate verification issues:

```
curl: (60) SSL certificate problem: unable to get local issuer certificate
```

This commonly occurs with Docker Desktop on macOS when corporate proxies or VPNs intercept SSL traffic. Even with `ca-certificates` installed and updated, the curl installer can fail. Using pip to install uv sidesteps this issue entirely while achieving the same result.

The original approach downloaded uv to `/root/.local/bin/` and required manual `mv` commands to relocate binaries. With pip, both `uv` and `uvx` are installed directly to `/usr/local/bin/` as entry points, so no relocation is needed.

## Test plan
- [x] `docker build --no-cache -f docker/Dockerfile.sandbox -t ash-sandbox .` succeeds
- [x] `uv run ash sandbox build` succeeds
- [x] `uvx` is available at `/usr/local/bin/uvx`
- [x] Sandbox image builds and ash-sb CLI works correctly